### PR TITLE
removed-date-compliance-confirmation

### DIFF
--- a/app/views/new-service-user/v5/attendance-add-8.html
+++ b/app/views/new-service-user/v5/attendance-add-8.html
@@ -25,9 +25,6 @@ Case summary
           <h1 class="govuk-panel__title">
             Compliance confirmed
           </h1>
-          <div class="govuk-panel__body">
-            <br>Thursday 11 February at 1:00 pm
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Removed the date from the compliance confirmation screen (should save us from having to update this in other iterations)