### PR TITLE
Separate storage and presentation when rendering appointment dates

### DIFF
--- a/app/data/case-list-data.js
+++ b/app/data/case-list-data.js
@@ -19,7 +19,7 @@ module.exports = {
       ],
       "type": "CJA - Indeterminate Public Prot.",
       "risk": "Medium",
-      "nextAppointment": "Monday 7 December at 9:30am"
+      "nextAppointment": "2020-12-07T09:30:00"
     },
     {
       "name": "Spencer Gill",

--- a/app/data/case-list-data.js
+++ b/app/data/case-list-data.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "caseList": [
     {
       "name": "Dylan Adam Armstrong",

--- a/app/filters.js
+++ b/app/filters.js
@@ -1,3 +1,7 @@
+const fs = require('fs')
+const path = require('path')
+const { DateTime } = require('luxon')
+
 module.exports = function (env) {
   /**
    * Instantiate object used to store the methods registered as a
@@ -7,39 +11,11 @@ module.exports = function (env) {
    */
   var filters = {}
 
-  /* ------------------------------------------------------------------
-    add your methods to the filters obj below this comment block:
-    @example:
+  // example: Monday 7 December at 9:30am
+  filters.dateAndTimeWithDayAndWithoutYear = date => {
+    var datetime = DateTime.fromISO(date)
+    return datetime.toFormat('cccc d MMMM') + ' at ' + datetime.toFormat('h:mma').toLowerCase();
+  }
 
-    filters.sayHi = function(name) {
-        return 'Hi ' + name + '!'
-    }
-
-    Which in your templates would be used as:
-
-    {{ 'Paul' | sayHi }} => 'Hi Paul'
-
-    Notice the first argument of your filters method is whatever
-    gets 'piped' via '|' to the filter.
-
-    Filters can take additional arguments, for example:
-
-    filters.sayHi = function(name,tone) {
-      return (tone == 'formal' ? 'Greetings' : 'Hi') + ' ' + name + '!'
-    }
-
-    Which would be used like this:
-
-    {{ 'Joel' | sayHi('formal') }} => 'Greetings Joel!'
-    {{ 'Gemma' | sayHi }} => 'Hi Gemma!'
-
-    For more on filters and how to write them see the Nunjucks
-    documentation.
-
-  ------------------------------------------------------------------ */
-
-  /* ------------------------------------------------------------------
-    keep the following line to return your filters to the app
-  ------------------------------------------------------------------ */
   return filters
 }

--- a/app/views/includes/case-list-data.html
+++ b/app/views/includes/case-list-data.html
@@ -37,7 +37,7 @@
             <td class="govuk-table__cell">{{ case.risk }}</td>
             <td class="govuk-table__cell">
               {% if case.nextAppointment %}
-                {{ case.nextAppointment }}
+                {{ case.nextAppointment | dateAndTimeWithDayAndWithoutYear }}
               {% else %}
               <strong class="govuk-tag govuk-tag--grey">
                 Unscheduled

--- a/app/views/includes/case-list-data.html
+++ b/app/views/includes/case-list-data.html
@@ -46,7 +46,6 @@
             </td>
           </tr>
         {% endfor %}
-        </tr>
       </tbody>
 
     </table>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6048,7 +6048,8 @@
         },
         "yargs-parser": {
           "version": "13.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -7662,6 +7663,11 @@
       "requires": {
         "es5-ext": "~0.10.2"
       }
+    },
+    "luxon": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
+      "integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A=="
     },
     "make-dir": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "gulp-sass": "^4.0.1",
     "gulp-sourcemaps": "^2.6.0",
     "keypather": "^3.0.0",
+    "luxon": "^1.24.1",
     "marked": "^0.7.0",
     "notifications-node-client": "^4.1.0",
     "nunjucks": "^3.2.2",

--- a/server.js
+++ b/server.js
@@ -207,7 +207,7 @@ if (useCookieSessionStore === 'true') {
 }
 
 // Load global datasets into nunjucks environment
-const caseListData = require(path.join(__dirname, 'app/data/case-list-data.json'));
+const caseListData = require(path.join(__dirname, 'app/data/case-list-data.js'));
 utils.addGlobalData(nunjucksAppEnv, "caseListData", caseListData);
 
 // Automatically store all data users enter


### PR DESCRIPTION
Changes:

- turn the JSON data into a JS file, which will allow DSLs when defining the test data (e.g. putting dates n days in future)
- store the appointment date as a date, and move the formatting into a filter