### PR TITLE
Make the navigation component reusable

### DIFF
--- a/app/views/includes/navigation.html
+++ b/app/views/includes/navigation.html
@@ -1,0 +1,43 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <nav class="moj-sub-navigation" aria-label="Sub navigation">
+      <ul class="moj-sub-navigation__list">
+        <li class="moj-sub-navigation__item">
+          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
+            {% if currentNavSection == 'progress' %}
+            aria-current="page"
+            {% endif %}
+            href="progress.html">Progress</a>
+        </li>
+        <li class="moj-sub-navigation__item">
+          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
+            {% if currentNavSection == 'plan' %}
+            aria-current="page"
+            {% endif %}
+            href="plan.html">Plan</a>
+        </li>
+        <li class="moj-sub-navigation__item">
+          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
+            {% if currentNavSection == 'timeline' %}
+            aria-current="page"
+            {% endif %}
+            href="timeline.html">Previous sessions</a>
+        </li>
+        <li class="moj-sub-navigation__item">
+          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
+            {% if currentNavSection == 'details' %}
+            aria-current="page"
+            {% endif %}
+            href="details.html">Personal details</a>
+        </li>
+        <li class="moj-sub-navigation__item">
+          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
+            {% if currentNavSection == 'sentence' %}
+            aria-current="page"
+            {% endif %}
+            href="sentence.html">Sentence</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>

--- a/app/views/v6/details.html
+++ b/app/views/v6/details.html
@@ -18,35 +18,8 @@ Case summary
 
 {% block content %}
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <nav class="moj-sub-navigation" aria-label="Sub navigation">
-      <ul class="moj-sub-navigation__list">
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
-            href="progress.html">Progress</a>
-        </li>
-
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state" 
-            href="plan.html">Plan</a>
-        </li>
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
-            href="timeline.html">Previous sessions</a>
-        </li>
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state" aria-current="page"
-            href="details.html">Personal details</a>
-        </li>
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
-            href="sentence.html">Sentence</a>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
+{% set currentNavSection = 'details' %}
+{% include "includes/navigation.html" %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -76,7 +49,7 @@ Case summary
         </div>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            Phone number 
+            Phone number
           </dt>
           <dd class="govuk-summary-list__value">
             07700 900 077
@@ -132,7 +105,7 @@ Case summary
         </div>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            Preferred language	
+            Preferred language
           </dt>
           <dd class="govuk-summary-list__value">
             English
@@ -164,7 +137,7 @@ Case summary
           <dl class="govuk-summary-list govuk-summary-list--no-border">
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
-                Nationality	
+                Nationality
               </dt>
               <dd class="govuk-summary-list__value">
                 British
@@ -172,7 +145,7 @@ Case summary
             </div>
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
-                Ethnicity	
+                Ethnicity
               </dt>
               <dd class="govuk-summary-list__value">
                 White: British
@@ -180,7 +153,7 @@ Case summary
             </div>
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
-                Religion or belief	
+                Religion or belief
               </dt>
               <dd class="govuk-summary-list__value">
                 None
@@ -188,7 +161,7 @@ Case summary
             </div>
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
-                Gender		
+                Gender
               </dt>
               <dd class="govuk-summary-list__value">
                 Male
@@ -196,7 +169,7 @@ Case summary
             </div>
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
-                Sexual orientation	
+                Sexual orientation
               </dt>
               <dd class="govuk-summary-list__value">
                 Heterosexual
@@ -262,12 +235,12 @@ Case summary
           </li>
         </ul>
       </div>
-    </div>  
-    
-  
-  
+    </div>
+
+
+
   </div>
 
-</div>      
+</div>
 
 {% endblock %}

--- a/app/views/v6/plan.html
+++ b/app/views/v6/plan.html
@@ -18,35 +18,8 @@ Case summary
 
 {% block content %}
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <nav class="moj-sub-navigation" aria-label="Sub navigation">
-      <ul class="moj-sub-navigation__list">
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
-            href="progress.html">Progress</a>
-        </li>
-
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state" aria-current="page"
-            href="plan.html">Plan</a>
-        </li>
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
-            href="timeline.html">Previous sessions</a>
-        </li>
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
-            href="details.html">Personal details</a>
-        </li>
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
-            href="sentence.html">Sentence</a>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
+{% set currentNavSection = 'plan' %}
+{% include "includes/navigation.html" %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -110,5 +83,5 @@ Case summary
 <div class="govuk-grid-column-one-third">
 
 
-</div>      
+</div>
     {% endblock %}

--- a/app/views/v6/progress.html
+++ b/app/views/v6/progress.html
@@ -18,35 +18,8 @@ Case summary
 
 {% block content %}
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <nav class="moj-sub-navigation" aria-label="Sub navigation">
-      <ul class="moj-sub-navigation__list">
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state" aria-current="page"
-            href="progress.html">Progress</a>
-        </li>
-
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state" 
-            href="plan.html">Plan</a>
-        </li>
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
-            href="timeline.html">Previous sessions</a>
-        </li>
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
-            href="details.html">Personal details</a>
-        </li>
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
-            href="sentence.html">Sentence</a>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
+{% set currentNavSection = 'progress' %}
+{% include "includes/navigation.html" %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -96,12 +69,12 @@ Case summary
       </div>
     </div>
   </div>
-  
+
     <!--<div class="moj-banner">
       <div class="moj-banner__message">
         <h2 class="govuk-heading-m">This will be updated as the sentence progresses.</h2>
       </div>
-    </div>--> 
+    </div>-->
 
     <!--TO DO LIST-->
     <!--<div class="govuk-!-margin-bottom-7">
@@ -126,7 +99,7 @@ Case summary
               Office visit on 1 March 2021 at 1:00pm
             </p>
           </div>
-        </li>  
+        </li>
       </ul>
     </div>
 
@@ -136,7 +109,7 @@ Case summary
       <h2 class="govuk-heading-m">
         Risks
       </h2>
-    
+
       <dl class="govuk-summary-list govuk-summary-list--no-border">
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
@@ -184,7 +157,7 @@ Case summary
         </div>
       </dl>
     </div>
-    
+
   </div>
 
   <div class="govuk-grid-column-one-third">
@@ -214,9 +187,9 @@ Case summary
     </div>
   </div>
 
-  
+
   </div>
-    
+
 </div>
-  
+
     {% endblock %}

--- a/app/views/v6/sentence.html
+++ b/app/views/v6/sentence.html
@@ -18,35 +18,8 @@ Case summary
 
 {% block content %}
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <nav class="moj-sub-navigation" aria-label="Sub navigation">
-      <ul class="moj-sub-navigation__list">
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
-            href="progress.html">Progress</a>
-        </li>
-
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state" 
-            href="plan.html">Plan</a>
-        </li>
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
-            href="timeline.html">Previous sessions</a>
-        </li>
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
-            href="details.html">Personal details</a>
-        </li>
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state" aria-current="page"
-            href="sentence.html">Sentence</a>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
+{% set currentNavSection = 'sentence' %}
+{% include "includes/navigation.html" %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -57,7 +30,7 @@ Case summary
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    
+
       <div class="govuk-!-margin-bottom-7">
         <h2 class="govuk-heading-m">
           Community Order
@@ -82,7 +55,7 @@ Case summary
         </div>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            End date		
+            End date
           </dt>
           <dd class="govuk-summary-list__value">
             4 January 2022
@@ -108,7 +81,7 @@ Case summary
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">
-              Fine		
+              Fine
             </dt>
             <dd class="govuk-summary-list__value">
               £1,000
@@ -126,7 +99,7 @@ Case summary
           <dl class="govuk-summary-list govuk-summary-list--no-border">
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
-                Offence date		
+                Offence date
               </dt>
               <dd class="govuk-summary-list__value">
                 15 November 2020
@@ -134,7 +107,7 @@ Case summary
             </div>
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
-                Conviction date	
+                Conviction date
               </dt>
               <dd class="govuk-summary-list__value">
                 12 December 2020
@@ -142,7 +115,7 @@ Case summary
             </div>
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
-                Court	
+                Court
               </dt>
               <dd class="govuk-summary-list__value">
                 Sheffield Magistrates' Court
@@ -150,7 +123,7 @@ Case summary
             </div>
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
-                Responsible court		
+                Responsible court
               </dt>
               <dd class="govuk-summary-list__value">
                 Sheffield Magistrates' Court
@@ -188,7 +161,7 @@ Case summary
             </li>
           </ul>
         </div>
-      </div>    
+      </div>
 
    </div>
     <h2 class="govuk-heading-m">Dylan's history</h2>
@@ -218,6 +191,6 @@ Case summary
     </p>
   </div>
 
-</div><!--END GRID ROW-->     
+</div><!--END GRID ROW-->
 
 {% endblock %}

--- a/app/views/v6/timeline.html
+++ b/app/views/v6/timeline.html
@@ -17,35 +17,8 @@ Case summary
 {% endblock %}
 
 {% block content %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <nav class="moj-sub-navigation" aria-label="Sub navigation">
-      <ul class="moj-sub-navigation__list">
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
-            href="progress.html">Progress</a>
-        </li>
-
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state" 
-            href="plan.html">Plan</a>
-        </li>
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state" aria-current="page"
-            href="timeline.html">Previous sessions</a>
-        </li>
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state" 
-            href="details.html">Personal details</a>
-        </li>
-        <li class="moj-sub-navigation__item">
-          <a class="moj-sub-navigation__link govuk-link--no-visited-state"
-            href="sentence.html">Sentence</a>
-        </li>
-      </ul>
-    </nav>
-  </div>
-</div>
+{% set currentNavSection = 'timeline' %}
+{% include "includes/navigation.html" %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -60,7 +33,7 @@ Case summary
         <div class="moj-timeline">
 
       <!--ATTENDANCE NOT CONFIRMED-->
-      <div class="moj-timeline__item">   
+      <div class="moj-timeline__item">
         <div class="moj-timeline__header">
           <h2 class="moj-timeline__title">Office visit</h2>
           <p class="moj-timeline__byline">by Mark Berridge
@@ -72,65 +45,65 @@ Case summary
         <div class="moj-timeline__description">
           <div class="moj-banner moj-banner--warning">
             <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
-            <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z" /></svg>    
+            <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z" /></svg>
             <div class="moj-banner__message">
-            <span class="moj-banner__assistive">Warning</span>Attendance not confirmed.    <a href="confirm-attendance/attendance-add-1.html">Confirm attendance</a></div>  
-            </div> 
+            <span class="moj-banner__assistive">Warning</span>Attendance not confirmed.    <a href="confirm-attendance/attendance-add-1.html">Confirm attendance</a></div>
+            </div>
           </p>
         </div>
         </div>
 
           <div class="moj-timeline__item">
             <div class="moj-timeline__header">
-              <h2 class="moj-timeline__title">Text message from Dylan</h2>  
+              <h2 class="moj-timeline__title">Text message from Dylan</h2>
             </div>
-            
+
             <p class="moj-timeline__date">
               <time datetime="2019-06-14T14:01:00.000Z">22 April 2021 at 1:00pm</time>
             </p>
-      
+
             <div class="moj-timeline__description">
               <div class="note-panel">
                 <p style="margin-bottom: 0px;">Hi Mark, got the email. I’ll be there. D.</p>
               </div>
             </div>
-          
+
             </div>
             <div class="moj-timeline__item">
-          
+
               <div class="moj-timeline__header">
                 <h2 class="moj-timeline__title">Email to Dylan</h2>
               </div>
-              
+
               <p class="moj-timeline__date">
                 <time datetime="2019-06-14T14:01:00.000Z">10 April 2021 at 1:00pm</time>
               </p>
-        
+
               <div class="moj-timeline__description">
                 <div class="note-panel">
                   <p>
-                    Hi Dylan, 
+                    Hi Dylan,
                   </p>
                   <p>
-                    It’s really important that you come back in to see me. I understand that my last letter was sent to your old room so I’m trying you on the email address you provided me. 
-                    We talked at the beginning of your probation about what might happen if you refuse to comply... 
+                    It’s really important that you come back in to see me. I understand that my last letter was sent to your old room so I’m trying you on the email address you provided me.
+                    We talked at the beginning of your probation about what might happen if you refuse to comply...
                   </p>
                   <a href="#">View full details</a>
                 </div>
               </div>
-            
+
               </div>
               <div class="moj-timeline__item">
-          
+
                 <div class="moj-timeline__header">
                   <h2 class="moj-timeline__title">
                     Email to a third party</h2>
                 </div>
-                
+
                 <p class="moj-timeline__date">
                   <time datetime="2019-06-14T14:01:00.000Z">31 March 2021 at 1:00pm</time>
                 </p>
-          
+
                 <div class="moj-timeline__description">
                   <div class="note-panel">
                     <p>
@@ -143,25 +116,25 @@ Case summary
                     <a href="#">View full details</a>
                   </div>
                 </div>
-              
+
                 </div>
                 <div class="moj-timeline__item">
-          
+
                   <div class="moj-timeline__header">
                     <h2 class="moj-timeline__title">Office visit</h2>
-                  
+
                     <p class="moj-timeline__byline">by Mark Berridge
                       &NonBreakingSpace;<strong class="govuk-tag govuk-tag--red">
                         Failed to comply
                       </strong>
                     </p>
-                  
+
                   </div>
-                  
+
                   <p class="moj-timeline__date">
                     <time datetime="2019-06-14T14:01:00.000Z">16 March 2021 at 1:00pm</time>
                   </p>
-            
+
                   <div class="moj-timeline__description">
                     <div class="note-panel">
                       <p style="margin-bottom: 0px;">
@@ -169,26 +142,26 @@ Case summary
                       </p>
                     </div>
                   </div>
-                
+
                   </div>
                   <div class="moj-timeline__item">
-          
+
                     <div class="moj-timeline__header">
                       <h2 class="moj-timeline__title">Email from a third party</h2>
-                    
+
                     </div>
-                    
+
                     <p class="moj-timeline__date">
                       <time datetime="2019-06-14T14:01:00.000Z">12 March 2021 at 1:00pm</time>
                     </p>
-              
+
                     <div class="moj-timeline__description">
                       <div class="note-panel">
                         <p>
                           Dear Mark,
                         </p>
                         <p>
-                          Thanks for your email, I’ve received Dylan’s request and we have a room available on the ground floor coming available on the 19th of March. 
+                          Thanks for your email, I’ve received Dylan’s request and we have a room available on the ground floor coming available on the 19th of March.
                         </p>
                         <p>
                           All the best,...
@@ -198,19 +171,19 @@ Case summary
                         <a href="#">View full details</a>
                       </div>
                     </div>
-                  
+
                     </div>
                      <div class="moj-timeline__item">
-          
+
           <div class="moj-timeline__header">
             <h2 class="moj-timeline__title">Email to a third party</h2>
-          
+
           </div>
-          
+
           <p class="moj-timeline__date">
             <time datetime="2019-06-14T14:01:00.000Z">27 February 2021 at 1:00pm</time>
           </p>
-    
+
           <div class="moj-timeline__description">
             <div class="note-panel">
               <p>
@@ -222,26 +195,26 @@ Case summary
               <a href="#">View full details</a>
             </div>
           </div>
-        
+
           </div>
 
           <div class="moj-timeline__item">
-          
+
           <div class="moj-timeline__header">
             <h2 class="moj-timeline__title">Office visit</h2>
-          
+
             <p class="moj-timeline__byline">by Mark Berridge
               &NonBreakingSpace;<strong class="govuk-tag govuk-tag--green">
                 Comply
               </strong>
             </p>
-          
+
           </div>
-          
+
           <p class="moj-timeline__date">
             <time datetime="2019-06-14T14:01:00.000Z">8 February 2021 at 1:00pm</time>
           </p>
-    
+
           <div class="moj-timeline__description">
             <div class="note-panel">
               <p>Dylan arrived on time and presented well for his induction appointment. He filled in all the paperwork required without any resistance and said he understood the process. He mentioned his mum had talked to him a lot over the weekend and helped him to calm down. His mum appears to be a positive influence in his life, which I would like to explore further with him.
@@ -249,26 +222,26 @@ Case summary
               <a href="#">View full details</a>
             </div>
           </div>
-        
+
           </div>
-          
+
           <div class="moj-timeline__item">
-          
+
           <div class="moj-timeline__header">
             <h2 class="moj-timeline__title">Phone call</h2>
-          
+
             <p class="moj-timeline__byline">by Mark Berridge
               &NonBreakingSpace;<strong class="govuk-tag govuk-tag--red">
                 Failed to comply
               </strong>
             </p>
-          
+
           </div>
-          
+
           <p class="moj-timeline__date">
             <time datetime="2019-06-07T12:32:00.000Z">3 February at 13:00pm</time>
           </p>
-          
+
           <div class="moj-timeline__description">
             <div class="note-panel">
               <p>I called Dylan to confirm he had understood where he needed to be and when for his induction appointment. He was rude and abusive and in general very hostile in reaction to his sentence saying this wasn’t his fault. He mentioned he “doesn’t have time for this”. I reiterated that he must be at the office on Monday as part of his sentence requirements and if he doesn’t it’s going to reflect very poorly.
@@ -276,22 +249,22 @@ Case summary
             <a href="timeline-entry-call">View full details</a>
           </div>
           </div>
-          
+
           </div>
-           
+
           <div class="moj-timeline__item">
-          
+
           <div class="moj-timeline__header">
             <h2 class="moj-timeline__title">Communication with a third party</h2>
-          
+
             <p class="moj-timeline__byline">by Mark Berridge</p>
-          
+
           </div>
-          
+
           <p class="moj-timeline__date">
             <time datetime="2019-05-28T10:15:00.000Z">2 February at 10:15pm</time>
           </p>
-          
+
           <div class="moj-timeline__description">
             <div class="note-panel">
               <ul class="moj-timeline__documents">
@@ -304,16 +277,16 @@ Case summary
               </ul>
             </div>
           </div>
-          
+
           </div>
-        
+
           </div>
 
     </div>
     <div class="govuk-grid-column-one-third">
 
       <div class="govuk-!-margin-bottom-7">
-    
+
       <!--ADD A NOTE OR DOCUMENT-->
       <!--<h2 class="govuk-heading-m">
         Actions
@@ -324,10 +297,10 @@ Case summary
         </a>
         </p>
       </div>-->
-    
+
         <h2 class="govuk-heading-m">Dylan's session summary</h2>
         <p class="govuk-body">Summary up to and including 22 April 2021</p>
-    
+
         <div class="govuk-!-margin-bottom-7">
           <table class="govuk-table app-table govuk-!-margin-top-0 govuk-!-margin-bottom-3" style="max-width:none;">
             <tbody class="govuk-table__body">
@@ -374,9 +347,9 @@ Case summary
             </tbody>
           </table>
         </div>
-    
-    </div>       
-    
-    
+
+    </div>
+
+
 </div>
     {% endblock %}


### PR DESCRIPTION
This only replaces the nav for the main 5 pages.

There's lots of training whitespace in these files, if you want to ignore those changes, use this link:

https://github.com/ministryofjustice/hmpps-steel-thread/pull/86/files?diff=split&w=1