### PR TITLE
Only apply autocomplete on pages with appropriate elements

### DIFF
--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -104,5 +104,9 @@ var times = [
 ]
 
 /* initiate the autocomplete function on the "myInput" element, and pass along the times array as possible autocomplete values: */
-autocomplete(document.getElementById('myInput'), times)
-autocomplete(document.getElementById('myInput-2'), times)
+if (document.getElementById('myInput')) {
+  autocomplete(document.getElementById('myInput'), times)
+}
+if (document.getElementById('myInput-2')) {
+  autocomplete(document.getElementById('myInput-2'), times)
+}


### PR DESCRIPTION
## Context

There are JS errors on the console on pages that don't have the autocomplete elements (start and end time fields).

## What's changed

Only attempt applying the autocomplete when the relevant elements are present on the page.

 