### PR TITLE
Pull data out of 'contacts' and 'personal details' pages

### DIFF
--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -16,6 +16,11 @@ module.exports = {
         'email': 'example@example.com',
         'aliases': ['Dee'],
         'preferredLanguage': 'English',
+        'nationality': 'British',
+        'ethnicity': 'White: British',
+        'religion': 'None',
+        'gender': 'Male',
+        'sexualOrientation': 'Heterosexual',
         'disabilitiesAndAdjustments': ['Autism spectrum condition'],
         'circumstances': {
           'employment': 'Full-time employed',

--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -11,8 +11,30 @@ module.exports = {
           'Sheffield',
           'South Yorkshire',
           'S10 1AG'
-        ]
+        ],
+        'phone': '07700 900 077',
+        'email': 'example@example.com',
+        'aliases': ['Dee'],
+        'preferredLanguage': 'English',
+        'disabilitiesAndAdjustments': ['Autism spectrum condition'],
+        'circumstances': {
+          'employment': 'Full-time employed',
+          'housingStatus': 'Living alone',
+          'safeguardingIssues': []
+        }
       },
+      'personalContacts': [
+        {
+          'name': 'Pippa Wade',
+          'relationship': 'Mum',
+          'address': [
+            '2 Grey Lane',
+            'Sheffield',
+            'South Yorkshire',
+            'S10 1AG'
+          ]
+        }
+      ],
       'PNC': '2012/123400000F',
       'CRN': 'J678910',
       'currentOrder': {

--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -40,6 +40,17 @@ module.exports = {
           ]
         }
       ],
+      'professionalContacts': [
+        {
+          'name': 'Gary Millar',
+          'phone': '0114 123 0000',
+          'email': 'example@example.com',
+          'provider': 'CPA South Yorkshire',
+          'localDeliveryUnit': 'Rotherham',
+          'team': 'Rotherham LMC',
+          'allocatedUntilDate': '2019-11-19'
+        }
+      ],
       'PNC': '2012/123400000F',
       'CRN': 'J678910',
       'currentOrder': {

--- a/app/data/cases.js
+++ b/app/data/cases.js
@@ -5,7 +5,13 @@ module.exports = {
         'name': 'Dylan Adam Armstrong',
         'firstName': 'Dylan',
         'dateOfBirth': '1984-09-27',
-        'age': 35
+        'age': 35,
+        'address': [
+          '1 Grey Lane',
+          'Sheffield',
+          'South Yorkshire',
+          'S10 1AG'
+        ]
       },
       'PNC': '2012/123400000F',
       'CRN': 'J678910',

--- a/app/views/includes/head.html
+++ b/app/views/includes/head.html
@@ -73,7 +73,7 @@
           </li> -->
 
           <li class="moj-primary-navigation__item">
-            <a class="moj-primary-navigation__link" href="#">My cases</a>
+            <a class="moj-primary-navigation__link" href="/prototype/case-list">My cases</a>
           </li>
         </ul>
       </nav>

--- a/app/views/prototype/address-book-personal.html
+++ b/app/views/prototype/address-book-personal.html
@@ -63,7 +63,7 @@ Case summary
             Phone number
           </dt>
           <dd class="govuk-summary-list__value">
-            07700 900 077
+            {{ case.serviceUserPersonalDetails.phone }}
           </dd>
         </div>
         <div class="govuk-summary-list__row">
@@ -71,38 +71,37 @@ Case summary
             Email
           </dt>
           <dd class="govuk-summary-list__value">
-            example@example.com
+            {{ case.serviceUserPersonalDetails.email }}
           </dd>
         </div>
       </dl>
     </div>
 
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    {% for contact in case.personalContacts %}
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-    <div class="govuk-!-margin-bottom-7">
-      <h2 class="govuk-heading-m">Pippa Wade</h2>
-      <dl class="govuk-summary-list govuk-summary-list--no-border">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Relationship to {{ case.serviceUserPersonalDetails.firstName }}
-          </dt>
-          <dd class="govuk-summary-list__value">
-            Mum
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Address
-          </dt>
-          <dd class="govuk-summary-list__value">
-            2 Grey Lane<br>
-            Sheffield<br>
-            South Yorkshire<br>
-            S10 1AG
-          </dd>
-        </div>
-      </dl>
-    </div>
+      <div class="govuk-!-margin-bottom-7">
+        <h2 class="govuk-heading-m">{{ contact.name }}</h2>
+        <dl class="govuk-summary-list govuk-summary-list--no-border">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Relationship to {{ case.serviceUserPersonalDetails.firstName }}
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ contact.relationship }}
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Address
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ contact.address.join('<br>') | safe }}
+            </dd>
+          </div>
+        </dl>
+      </div>
+    {% endfor %}
 
   </div>
 </div>

--- a/app/views/prototype/address-book-personal.html
+++ b/app/views/prototype/address-book-personal.html
@@ -49,32 +49,24 @@ Case summary
       <h2 class="govuk-heading-m">
         {{ case.serviceUserPersonalDetails.firstName }}’s contact details
       </h2>
-      <dl class="govuk-summary-list govuk-summary-list--no-border">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Address
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ case.serviceUserPersonalDetails.address.join('<br>') | safe }}
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Phone number
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ case.serviceUserPersonalDetails.phone }}
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Email
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ case.serviceUserPersonalDetails.email }}
-          </dd>
-        </div>
-      </dl>
+
+      {{ govukSummaryList({
+        classes: 'govuk-summary-list--no-border',
+        rows: [
+          {
+            key: { text: "Address" },
+            value: { html: case.serviceUserPersonalDetails.address.join('<br>') }
+          },
+          {
+            key: { text: "Phone number" },
+            value: { text: case.serviceUserPersonalDetails.phone }
+          },
+          {
+            key: { text: "Email" },
+            value: { text: case.serviceUserPersonalDetails.email }
+          }
+        ]
+      }) }}
     </div>
 
     {% for contact in case.personalContacts %}
@@ -82,24 +74,20 @@ Case summary
 
       <div class="govuk-!-margin-bottom-7">
         <h2 class="govuk-heading-m">{{ contact.name }}</h2>
-        <dl class="govuk-summary-list govuk-summary-list--no-border">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Relationship to {{ case.serviceUserPersonalDetails.firstName }}
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ contact.relationship }}
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Address
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ contact.address.join('<br>') | safe }}
-            </dd>
-          </div>
-        </dl>
+
+        {{ govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          rows: [
+            {
+              key: { text: "Relationship to " + case.serviceUserPersonalDetails.firstName },
+              value: { text: contact.relationship }
+            },
+            {
+              key: { text: "Address" },
+              value: { html: contact.address.join('<br>') }
+            }
+          ]
+        }) }}
       </div>
     {% endfor %}
 

--- a/app/views/prototype/address-book-personal.html
+++ b/app/views/prototype/address-book-personal.html
@@ -55,10 +55,7 @@ Case summary
             Address
           </dt>
           <dd class="govuk-summary-list__value">
-            1 Grey Lane<br>
-            Sheffield<br>
-            South Yorkshire<br>
-            S10 1AG
+            {{ case.serviceUserPersonalDetails.address.join('<br>') | safe }}
           </dd>
         </div>
         <div class="govuk-summary-list__row">

--- a/app/views/prototype/address-book-personal.html
+++ b/app/views/prototype/address-book-personal.html
@@ -13,14 +13,14 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="details" class="govuk-back-link">Back to Dylan's details</a>
+<a href="details" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s details</a>
 {% endblock %}
 
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">Dylan's address book</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}'s address book</h1>
   </div>
 </div>
 
@@ -47,7 +47,7 @@ Case summary
 
     <div class="govuk-!-margin-bottom-7">
       <h2 class="govuk-heading-m">
-        Dylan's contact details
+        {{ case.serviceUserPersonalDetails.firstName }}'s contact details
       </h2>
       <dl class="govuk-summary-list govuk-summary-list--no-border">
         <div class="govuk-summary-list__row">
@@ -87,7 +87,7 @@ Case summary
       <dl class="govuk-summary-list govuk-summary-list--no-border">
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            Relationship to Dylan
+            Relationship to {{ case.serviceUserPersonalDetails.firstName }}
           </dt>
           <dd class="govuk-summary-list__value">
             Mum

--- a/app/views/prototype/address-book-personal.html
+++ b/app/views/prototype/address-book-personal.html
@@ -13,14 +13,14 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="details" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s details</a>
+<a href="details" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s details</a>
 {% endblock %}
 
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}'s address book</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}’s address book</h1>
   </div>
 </div>
 
@@ -47,7 +47,7 @@ Case summary
 
     <div class="govuk-!-margin-bottom-7">
       <h2 class="govuk-heading-m">
-        {{ case.serviceUserPersonalDetails.firstName }}'s contact details
+        {{ case.serviceUserPersonalDetails.firstName }}’s contact details
       </h2>
       <dl class="govuk-summary-list govuk-summary-list--no-border">
         <div class="govuk-summary-list__row">

--- a/app/views/prototype/address-book-professional.html
+++ b/app/views/prototype/address-book-professional.html
@@ -13,14 +13,14 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="details" class="govuk-back-link">Back to Dylan's details</a>
+<a href="details" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s details</a>
 {% endblock %}
 
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">Dylan's address book</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}'s address book</h1>
   </div>
 </div>
 

--- a/app/views/prototype/address-book-professional.html
+++ b/app/views/prototype/address-book-professional.html
@@ -13,14 +13,14 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="details" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s details</a>
+<a href="details" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s details</a>
 {% endblock %}
 
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}'s address book</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}’s address book</h1>
   </div>
 </div>
 

--- a/app/views/prototype/address-book-professional.html
+++ b/app/views/prototype/address-book-professional.html
@@ -44,59 +44,65 @@ Case summary
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-!-margin-bottom-7">
-      <h2 class="govuk-heading-m">Gary Millar</h2>
-      <dl class="govuk-summary-list govuk-summary-list--no-border">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Phone number
-          </dt>
-          <dd class="govuk-summary-list__value">
-            0114 123 0000
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Email
-          </dt>
-          <dd class="govuk-summary-list__value">
-            example@example.com
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Provider
-          </dt>
-          <dd class="govuk-summary-list__value">
-            CPA South Yorkshire
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Local Delivery Unit (LDU)
-          </dt>
-          <dd class="govuk-summary-list__value">
-            Rotherham
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Team
-          </dt>
-          <dd class="govuk-summary-list__value">
-            Rotherham LMC
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Allocated until
-          </dt>
-          <dd class="govuk-summary-list__value">
-            19 November 2019
-          </dd>
-        </div>
-      </dl>
-    </div>
+    {% set hr = joiner('<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">') %}
+
+    {% for contact in case.professionalContacts %}
+      {{ hr() | safe }}
+
+      <div class="govuk-!-margin-bottom-7">
+        <h2 class="govuk-heading-m">{{ contact.name }}</h2>
+        <dl class="govuk-summary-list govuk-summary-list--no-border">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Phone number
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ contact.phone }}
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Email
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ contact.email }}
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Provider
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ contact.provider }}
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Local Delivery Unit (LDU)
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ contact.localDeliveryUnit }}
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Team
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ contact.team }}
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Allocated until
+            </dt>
+            <dd class="govuk-summary-list__value">
+              {{ contact.allocatedUntilDate | dateWithYear }}
+            </dd>
+          </div>
+        </dl>
+      </div>
+    {% endfor %}
 
   </div>
 </div>

--- a/app/views/prototype/address-book-professional.html
+++ b/app/views/prototype/address-book-professional.html
@@ -51,56 +51,36 @@ Case summary
 
       <div class="govuk-!-margin-bottom-7">
         <h2 class="govuk-heading-m">{{ contact.name }}</h2>
-        <dl class="govuk-summary-list govuk-summary-list--no-border">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Phone number
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ contact.phone }}
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Email
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ contact.email }}
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Provider
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ contact.provider }}
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Local Delivery Unit (LDU)
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ contact.localDeliveryUnit }}
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Team
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ contact.team }}
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Allocated until
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ contact.allocatedUntilDate | dateWithYear }}
-            </dd>
-          </div>
-        </dl>
+
+        {{ govukSummaryList({
+          classes: 'govuk-summary-list--no-border',
+          rows: [
+            {
+              key: { text: "Phone number" },
+              value: { text: contact.phone }
+            },
+            {
+              key: { text: "Email" },
+              value: { text: contact.email }
+            },
+            {
+              key: { text: "Provider" },
+              value: { text: contact.provider }
+            },
+            {
+              key: { text: "Local Delivery Unit (LDU)" },
+              value: { text: contact.localDeliveryUnit }
+            },
+            {
+              key: { text: "Team" },
+              value: { text: contact.team }
+            },
+            {
+              key: { text: "Allocated until" },
+              value: { text: contact.allocatedUntilDate | dateWithYear }
+            }
+          ]
+        }) }}
       </div>
     {% endfor %}
 

--- a/app/views/prototype/arrange-a-session/session-add-1.html
+++ b/app/views/prototype/arrange-a-session/session-add-1.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../progress" class="govuk-back-link">Back to Dylan's progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/arrange-a-session/session-add-1.html
+++ b/app/views/prototype/arrange-a-session/session-add-1.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/arrange-a-session/session-add-2.html
+++ b/app/views/prototype/arrange-a-session/session-add-2.html
@@ -25,28 +25,25 @@ Case summary
         When would you like to arrange this session?
       </h1>
 
-      <!--DYLANS CIRCUMSTANCES-->
-      <details class="govuk-details" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text">
-            {{ case.serviceUserPersonalDetails.firstName }}’s circumstances
-          </span>
-        </summary>
-        <div class="govuk-details__text">
-          <p class="govuk-body">
-            <strong>Preferred language</strong><br>
-            English
-          </p>
-          <p class="govuk-body">
-            <strong>Disabilities and adjustments</strong><br>
-            Autism spectrum condition
-          </p>
-          <p class="govuk-body">
-            <strong>Employment status</strong><br>
-            Full-time employed
-          </p>
-        </div>
-      </details>
+      {% set circumstancesHTML %}
+        <p class="govuk-body">
+          <strong>Preferred language</strong><br>
+          {{ case.serviceUserPersonalDetails.preferredLanguage }}
+        </p>
+        <p class="govuk-body">
+          <strong>Disabilities and adjustments</strong><br>
+          {{ case.serviceUserPersonalDetails.disabilitiesAndAdjustments.join(', ') }}
+        </p>
+        <p class="govuk-body">
+          <strong>Employment status</strong><br>
+          {{ case.serviceUserPersonalDetails.circumstances.employment }}
+        </p>
+      {% endset %}
+
+      {{ govukDetails({
+        summaryText: case.serviceUserPersonalDetails.firstName + "’s circumstances",
+        html: circumstancesHTML
+      }) }}
 
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" role="group" aria-describedby="passport-issued-hint">

--- a/app/views/prototype/arrange-a-session/session-add-2.html
+++ b/app/views/prototype/arrange-a-session/session-add-2.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -29,7 +29,7 @@ Case summary
       <details class="govuk-details" data-module="govuk-details">
         <summary class="govuk-details__summary">
           <span class="govuk-details__summary-text">
-            {{ case.serviceUserPersonalDetails.firstName }}'s circumstances
+            {{ case.serviceUserPersonalDetails.firstName }}’s circumstances
           </span>
         </summary>
         <div class="govuk-details__text">

--- a/app/views/prototype/arrange-a-session/session-add-2.html
+++ b/app/views/prototype/arrange-a-session/session-add-2.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../progress" class="govuk-back-link">Back to Dylan's progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -29,7 +29,7 @@ Case summary
       <details class="govuk-details" data-module="govuk-details">
         <summary class="govuk-details__summary">
           <span class="govuk-details__summary-text">
-            Dylan's circumstances
+            {{ case.serviceUserPersonalDetails.firstName }}'s circumstances
           </span>
         </summary>
         <div class="govuk-details__text">

--- a/app/views/prototype/arrange-a-session/session-add-3.html
+++ b/app/views/prototype/arrange-a-session/session-add-3.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../progress" class="govuk-back-link">Back to Dylan's progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/arrange-a-session/session-add-3.html
+++ b/app/views/prototype/arrange-a-session/session-add-3.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/arrange-a-session/session-add-4.html
+++ b/app/views/prototype/arrange-a-session/session-add-4.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../progress" class="govuk-back-link">Back to Dylan's progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/arrange-a-session/session-add-4.html
+++ b/app/views/prototype/arrange-a-session/session-add-4.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/arrange-a-session/session-add-5.html
+++ b/app/views/prototype/arrange-a-session/session-add-5.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../progress" class="govuk-back-link">Back to Dylan's progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -38,13 +38,13 @@ Case summary
       Add this session to your calendar.
     </p>
     <p class="govuk-body">
-      Give details of the session to Dylan.<br>
-      Dylan's phone number is <strong>07700 900 796</strong>.</p>
+      Give details of the session to {{ case.serviceUserPersonalDetails.firstName }}.<br>
+      {{ case.serviceUserPersonalDetails.firstName }}'s phone number is <strong>07700 900 796</strong>.</p>
 
-    <!--<p class="govuk-body">You may want to send a text message to Dylan. Dylan's phone number is <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
+    <!--<p class="govuk-body">You may want to send a text message to {{ case.serviceUserPersonalDetails.firstName }}. {{ case.serviceUserPersonalDetails.firstName }}'s phone number is <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
     <!--<p class="govuk-body">The session will be added to your Outlook calendar.</p>
-          <p class="govuk-body">A text message will be sent to Dylan on <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
-    <p class="govuk-body"><a href="../progress">Back to Dylan's progress</a></p>
+          <p class="govuk-body">A text message will be sent to {{ case.serviceUserPersonalDetails.firstName }} on <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
+    <p class="govuk-body"><a href="../progress">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a></p>
 
 
 

--- a/app/views/prototype/arrange-a-session/session-add-5.html
+++ b/app/views/prototype/arrange-a-session/session-add-5.html
@@ -39,11 +39,11 @@ Case summary
     </p>
     <p class="govuk-body">
       Give details of the session to {{ case.serviceUserPersonalDetails.firstName }}.<br>
-      {{ case.serviceUserPersonalDetails.firstName }}’s phone number is <strong>07700 900 796</strong>.</p>
+      {{ case.serviceUserPersonalDetails.firstName }}’s phone number is <strong>{{ case.serviceUserPersonalDetails.phone }}</strong>.</p>
 
-    <!--<p class="govuk-body">You may want to send a text message to {{ case.serviceUserPersonalDetails.firstName }}. {{ case.serviceUserPersonalDetails.firstName }}’s phone number is <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
+    <!--<p class="govuk-body">You may want to send a text message to {{ case.serviceUserPersonalDetails.firstName }}. {{ case.serviceUserPersonalDetails.firstName }}’s phone number is <strong>{{ case.serviceUserPersonalDetails.phone }}</strong>. <a href="#">Update phone number</a>.</p>-->
     <!--<p class="govuk-body">The session will be added to your Outlook calendar.</p>
-          <p class="govuk-body">A text message will be sent to {{ case.serviceUserPersonalDetails.firstName }} on <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
+          <p class="govuk-body">A text message will be sent to {{ case.serviceUserPersonalDetails.firstName }} on <strong>{{ case.serviceUserPersonalDetails.phone }}</strong>. <a href="#">Update phone number</a>.</p>-->
     <p class="govuk-body"><a href="../progress">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a></p>
 
 

--- a/app/views/prototype/arrange-a-session/session-add-5.html
+++ b/app/views/prototype/arrange-a-session/session-add-5.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -39,12 +39,12 @@ Case summary
     </p>
     <p class="govuk-body">
       Give details of the session to {{ case.serviceUserPersonalDetails.firstName }}.<br>
-      {{ case.serviceUserPersonalDetails.firstName }}'s phone number is <strong>07700 900 796</strong>.</p>
+      {{ case.serviceUserPersonalDetails.firstName }}’s phone number is <strong>07700 900 796</strong>.</p>
 
-    <!--<p class="govuk-body">You may want to send a text message to {{ case.serviceUserPersonalDetails.firstName }}. {{ case.serviceUserPersonalDetails.firstName }}'s phone number is <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
+    <!--<p class="govuk-body">You may want to send a text message to {{ case.serviceUserPersonalDetails.firstName }}. {{ case.serviceUserPersonalDetails.firstName }}’s phone number is <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
     <!--<p class="govuk-body">The session will be added to your Outlook calendar.</p>
           <p class="govuk-body">A text message will be sent to {{ case.serviceUserPersonalDetails.firstName }} on <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
-    <p class="govuk-body"><a href="../progress">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a></p>
+    <p class="govuk-body"><a href="../progress">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a></p>
 
 
 

--- a/app/views/prototype/arrange-a-session/session-update-1.html
+++ b/app/views/prototype/arrange-a-session/session-update-1.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -27,7 +27,7 @@ Case summary
             <h1 class="govuk-fieldset__heading govuk-label--l">
               What would you like to do?
             </h1>
-         
+
           </legend>
           <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
             <div class="govuk-radios__item">

--- a/app/views/prototype/arrange-a-session/session-update-1.html
+++ b/app/views/prototype/arrange-a-session/session-update-1.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/arrange-a-session/session-update-1.html
+++ b/app/views/prototype/arrange-a-session/session-update-1.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to Dylan's progress</a>
+<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/arrange-a-session/session-update-2.html
+++ b/app/views/prototype/arrange-a-session/session-update-2.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/arrange-a-session/session-update-2.html
+++ b/app/views/prototype/arrange-a-session/session-update-2.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -85,7 +85,7 @@ Case summary
           Save and continue
         </button>
       </div>
-    
+
     </form>
   </div>
 

--- a/app/views/prototype/arrange-a-session/session-update-2.html
+++ b/app/views/prototype/arrange-a-session/session-update-2.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to Dylan's progress</a>
+<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/arrange-a-session/session-update-3.html
+++ b/app/views/prototype/arrange-a-session/session-update-3.html
@@ -24,27 +24,25 @@ Case summary
       When would you like to arrange this session?
     </h1>
 
-    <details class="govuk-details" data-module="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          {{ case.serviceUserPersonalDetails.firstName }}’s circumstances
-        </span>
-      </summary>
-      <div class="govuk-details__text">
-        <p class="govuk-body">
-          <strong>Preferred language</strong><br>
-          English
-        </p>
-        <p class="govuk-body">
-          <strong>Disabilities and adjustments</strong><br>
-          Autism spectrum condition
-        </p>
-        <p class="govuk-body">
-          <strong>Employment status</strong><br>
-          Full-time employed
-        </p>
-      </div>
-    </details>
+    {% set circumstancesHTML %}
+      <p class="govuk-body">
+        <strong>Preferred language</strong><br>
+        {{ case.serviceUserPersonalDetails.preferredLanguage }}
+      </p>
+      <p class="govuk-body">
+        <strong>Disabilities and adjustments</strong><br>
+        {{ case.serviceUserPersonalDetails.disabilitiesAndAdjustments.join(', ') }}
+      </p>
+      <p class="govuk-body">
+        <strong>Employment status</strong><br>
+        {{ case.serviceUserPersonalDetails.circumstances.employment }}
+      </p>
+    {% endset %}
+
+    {{ govukDetails({
+      summaryText: case.serviceUserPersonalDetails.firstName + "’s circumstances",
+      html: circumstancesHTML
+    }) }}
 
     <form action="session-update-4" method="post" class="form">
 

--- a/app/views/prototype/arrange-a-session/session-update-3.html
+++ b/app/views/prototype/arrange-a-session/session-update-3.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -23,7 +23,7 @@ Case summary
     <h1 class="govuk-heading-l govuk-!-margin-bottom-7">
       When would you like to arrange this session?
     </h1>
-    
+
     <details class="govuk-details" data-module="govuk-details">
       <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
@@ -42,7 +42,7 @@ Case summary
         <p class="govuk-body">
           <strong>Employment status</strong><br>
           Full-time employed
-        </p>      
+        </p>
       </div>
     </details>
 
@@ -130,7 +130,7 @@ Case summary
                     </div>
                   </fieldset>
                 </div>
-                
+
                 <div class="govuk-form-group">
                   <fieldset class="govuk-fieldset" role="group" aria-describedby="passport-issued-hint">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
@@ -167,7 +167,7 @@ Case summary
       </button>
     </form>
   </div>
-  
+
 </div>
 
 {% endblock %}

--- a/app/views/prototype/arrange-a-session/session-update-3.html
+++ b/app/views/prototype/arrange-a-session/session-update-3.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to Dylan's progress</a>
+<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -27,7 +27,7 @@ Case summary
     <details class="govuk-details" data-module="govuk-details">
       <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
-          Dylan's circumstances
+          {{ case.serviceUserPersonalDetails.firstName }}'s circumstances
         </span>
       </summary>
       <div class="govuk-details__text">

--- a/app/views/prototype/arrange-a-session/session-update-3.html
+++ b/app/views/prototype/arrange-a-session/session-update-3.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -27,7 +27,7 @@ Case summary
     <details class="govuk-details" data-module="govuk-details">
       <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
-          {{ case.serviceUserPersonalDetails.firstName }}'s circumstances
+          {{ case.serviceUserPersonalDetails.firstName }}’s circumstances
         </span>
       </summary>
       <div class="govuk-details__text">

--- a/app/views/prototype/arrange-a-session/session-update-4.html
+++ b/app/views/prototype/arrange-a-session/session-update-4.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -33,7 +33,7 @@ Case summary
                 <div id="event-name-hint" class="govuk-hint">
                   This will account for one day of Rehabilitation Activity Requirement (RAR).
                 </div>
-             
+
               <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
                 <div class="govuk-radios__item">
                   <input class="govuk-radios__input" id="contact-2" name="contact" type="radio" value="phone" data-aria-controls="conditional-contact-2">
@@ -112,7 +112,7 @@ Case summary
             <label class="govuk-label govuk-label--l" for="more-detail">
               Add a calendar note (optional)
             </label>
-            <textarea class="govuk-textarea" id="more-detail" name="more-detail" rows="4" aria-describedby="more-detail-hint"></textarea> 
+            <textarea class="govuk-textarea" id="more-detail" name="more-detail" rows="4" aria-describedby="more-detail-hint"></textarea>
             </div>
 
             <button class="govuk-button send-message">

--- a/app/views/prototype/arrange-a-session/session-update-4.html
+++ b/app/views/prototype/arrange-a-session/session-update-4.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/arrange-a-session/session-update-4.html
+++ b/app/views/prototype/arrange-a-session/session-update-4.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to Dylan's progress</a>
+<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/arrange-a-session/session-update-5-cancel.html
+++ b/app/views/prototype/arrange-a-session/session-update-5-cancel.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/arrange-a-session/session-update-5-cancel.html
+++ b/app/views/prototype/arrange-a-session/session-update-5-cancel.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to Dylan's progress</a>
+<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -31,7 +31,7 @@ Case summary
             Reason for cancelling
           </dt>
           <dd class="govuk-summary-list__value">
-            Dylan's work shift has changed
+            {{ case.serviceUserPersonalDetails.firstName }}'s work shift has changed
           </dd>
           <dd class="govuk-summary-list__actions">
             <a class="govuk-link" href="#">

--- a/app/views/prototype/arrange-a-session/session-update-5-cancel.html
+++ b/app/views/prototype/arrange-a-session/session-update-5-cancel.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -31,7 +31,7 @@ Case summary
             Reason for cancelling
           </dt>
           <dd class="govuk-summary-list__value">
-            {{ case.serviceUserPersonalDetails.firstName }}'s work shift has changed
+            {{ case.serviceUserPersonalDetails.firstName }}’s work shift has changed
           </dd>
           <dd class="govuk-summary-list__actions">
             <a class="govuk-link" href="#">

--- a/app/views/prototype/arrange-a-session/session-update-5.html
+++ b/app/views/prototype/arrange-a-session/session-update-5.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/arrange-a-session/session-update-5.html
+++ b/app/views/prototype/arrange-a-session/session-update-5.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -31,7 +31,7 @@ Case summary
             Reason for rearranging
           </dt>
           <dd class="govuk-summary-list__value">
-            {{ case.serviceUserPersonalDetails.firstName }}'s work shift has changed
+            {{ case.serviceUserPersonalDetails.firstName }}’s work shift has changed
           </dd>
           <dd class="govuk-summary-list__actions">
             <a class="govuk-link" href="#">

--- a/app/views/prototype/arrange-a-session/session-update-5.html
+++ b/app/views/prototype/arrange-a-session/session-update-5.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to Dylan's progress</a>
+<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -31,7 +31,7 @@ Case summary
             Reason for rearranging
           </dt>
           <dd class="govuk-summary-list__value">
-            Dylan's work shift has changed
+            {{ case.serviceUserPersonalDetails.firstName }}'s work shift has changed
           </dd>
           <dd class="govuk-summary-list__actions">
             <a class="govuk-link" href="#">

--- a/app/views/prototype/arrange-a-session/session-update-6-cancel.html
+++ b/app/views/prototype/arrange-a-session/session-update-6-cancel.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to Dylan's progress</a>
+<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -37,13 +37,13 @@ Case summary
       Remove this session from your calendar.
     </p>
     <p class="govuk-body">
-      Let Dylan know.<br>
-      Dylan's phone number is <strong>07700 900 796</strong>.</p>
+      Let {{ case.serviceUserPersonalDetails.firstName }} know.<br>
+      {{ case.serviceUserPersonalDetails.firstName }}'s phone number is <strong>07700 900 796</strong>.</p>
 
-    <!--<p class="govuk-body">You may want to send a text message to Dylan. Dylan's phone number is <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
+    <!--<p class="govuk-body">You may want to send a text message to {{ case.serviceUserPersonalDetails.firstName }}. {{ case.serviceUserPersonalDetails.firstName }}'s phone number is <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
     <!--<p class="govuk-body">The session will be added to your Outlook calendar.</p>
-          <p class="govuk-body">A text message will be sent to Dylan on <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
-    <p class="govuk-body"><a href="../progress">Back to Dylan's progress</a></p>
+          <p class="govuk-body">A text message will be sent to {{ case.serviceUserPersonalDetails.firstName }} on <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
+    <p class="govuk-body"><a href="../progress">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a></p>
 
 
 

--- a/app/views/prototype/arrange-a-session/session-update-6-cancel.html
+++ b/app/views/prototype/arrange-a-session/session-update-6-cancel.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/arrange-a-session/session-update-6-cancel.html
+++ b/app/views/prototype/arrange-a-session/session-update-6-cancel.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -38,12 +38,12 @@ Case summary
     </p>
     <p class="govuk-body">
       Let {{ case.serviceUserPersonalDetails.firstName }} know.<br>
-      {{ case.serviceUserPersonalDetails.firstName }}'s phone number is <strong>07700 900 796</strong>.</p>
+      {{ case.serviceUserPersonalDetails.firstName }}’s phone number is <strong>07700 900 796</strong>.</p>
 
-    <!--<p class="govuk-body">You may want to send a text message to {{ case.serviceUserPersonalDetails.firstName }}. {{ case.serviceUserPersonalDetails.firstName }}'s phone number is <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
+    <!--<p class="govuk-body">You may want to send a text message to {{ case.serviceUserPersonalDetails.firstName }}. {{ case.serviceUserPersonalDetails.firstName }}’s phone number is <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
     <!--<p class="govuk-body">The session will be added to your Outlook calendar.</p>
           <p class="govuk-body">A text message will be sent to {{ case.serviceUserPersonalDetails.firstName }} on <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
-    <p class="govuk-body"><a href="../progress">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a></p>
+    <p class="govuk-body"><a href="../progress">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a></p>
 
 
 

--- a/app/views/prototype/arrange-a-session/session-update-6-cancel.html
+++ b/app/views/prototype/arrange-a-session/session-update-6-cancel.html
@@ -38,11 +38,11 @@ Case summary
     </p>
     <p class="govuk-body">
       Let {{ case.serviceUserPersonalDetails.firstName }} know.<br>
-      {{ case.serviceUserPersonalDetails.firstName }}’s phone number is <strong>07700 900 796</strong>.</p>
+      {{ case.serviceUserPersonalDetails.firstName }}’s phone number is <strong>{{ case.serviceUserPersonalDetails.phone }}</strong>.</p>
 
-    <!--<p class="govuk-body">You may want to send a text message to {{ case.serviceUserPersonalDetails.firstName }}. {{ case.serviceUserPersonalDetails.firstName }}’s phone number is <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
+    <!--<p class="govuk-body">You may want to send a text message to {{ case.serviceUserPersonalDetails.firstName }}. {{ case.serviceUserPersonalDetails.firstName }}’s phone number is <strong>{{ case.serviceUserPersonalDetails.phone }}</strong>. <a href="#">Update phone number</a>.</p>-->
     <!--<p class="govuk-body">The session will be added to your Outlook calendar.</p>
-          <p class="govuk-body">A text message will be sent to {{ case.serviceUserPersonalDetails.firstName }} on <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
+          <p class="govuk-body">A text message will be sent to {{ case.serviceUserPersonalDetails.firstName }} on <strong>{{ case.serviceUserPersonalDetails.phone }}</strong>. <a href="#">Update phone number</a>.</p>-->
     <p class="govuk-body"><a href="../progress">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a></p>
 
 

--- a/app/views/prototype/arrange-a-session/session-update-6.html
+++ b/app/views/prototype/arrange-a-session/session-update-6.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/arrange-a-session/session-update-6.html
+++ b/app/views/prototype/arrange-a-session/session-update-6.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="../progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -38,12 +38,12 @@ Case summary
     </p>
     <p class="govuk-body">
       Give details of the session to {{ case.serviceUserPersonalDetails.firstName }}.<br>
-      {{ case.serviceUserPersonalDetails.firstName }}'s phone number is <strong>07700 900 796</strong>.</p>
+      {{ case.serviceUserPersonalDetails.firstName }}’s phone number is <strong>07700 900 796</strong>.</p>
 
-    <!--<p class="govuk-body">You may want to send a text message to {{ case.serviceUserPersonalDetails.firstName }}. {{ case.serviceUserPersonalDetails.firstName }}'s phone number is <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
+    <!--<p class="govuk-body">You may want to send a text message to {{ case.serviceUserPersonalDetails.firstName }}. {{ case.serviceUserPersonalDetails.firstName }}’s phone number is <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
     <!--<p class="govuk-body">The session will be added to your Outlook calendar.</p>
           <p class="govuk-body">A text message will be sent to {{ case.serviceUserPersonalDetails.firstName }} on <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
-    <p class="govuk-body"><a href="../progress">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a></p>
+    <p class="govuk-body"><a href="../progress">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a></p>
 
 
 

--- a/app/views/prototype/arrange-a-session/session-update-6.html
+++ b/app/views/prototype/arrange-a-session/session-update-6.html
@@ -38,11 +38,11 @@ Case summary
     </p>
     <p class="govuk-body">
       Give details of the session to {{ case.serviceUserPersonalDetails.firstName }}.<br>
-      {{ case.serviceUserPersonalDetails.firstName }}’s phone number is <strong>07700 900 796</strong>.</p>
+      {{ case.serviceUserPersonalDetails.firstName }}’s phone number is <strong>{{ case.serviceUserPersonalDetails.phone }}</strong>.</p>
 
-    <!--<p class="govuk-body">You may want to send a text message to {{ case.serviceUserPersonalDetails.firstName }}. {{ case.serviceUserPersonalDetails.firstName }}’s phone number is <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
+    <!--<p class="govuk-body">You may want to send a text message to {{ case.serviceUserPersonalDetails.firstName }}. {{ case.serviceUserPersonalDetails.firstName }}’s phone number is <strong>{{ case.serviceUserPersonalDetails.phone }}</strong>. <a href="#">Update phone number</a>.</p>-->
     <!--<p class="govuk-body">The session will be added to your Outlook calendar.</p>
-          <p class="govuk-body">A text message will be sent to {{ case.serviceUserPersonalDetails.firstName }} on <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
+          <p class="govuk-body">A text message will be sent to {{ case.serviceUserPersonalDetails.firstName }} on <strong>{{ case.serviceUserPersonalDetails.phone }}</strong>. <a href="#">Update phone number</a>.</p>-->
     <p class="govuk-body"><a href="../progress">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a></p>
 
 

--- a/app/views/prototype/arrange-a-session/session-update-6.html
+++ b/app/views/prototype/arrange-a-session/session-update-6.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to Dylan's progress</a>
+<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -37,13 +37,13 @@ Case summary
       Add this session to your calendar.
     </p>
     <p class="govuk-body">
-      Give details of the session to Dylan.<br>
-      Dylan's phone number is <strong>07700 900 796</strong>.</p>
+      Give details of the session to {{ case.serviceUserPersonalDetails.firstName }}.<br>
+      {{ case.serviceUserPersonalDetails.firstName }}'s phone number is <strong>07700 900 796</strong>.</p>
 
-    <!--<p class="govuk-body">You may want to send a text message to Dylan. Dylan's phone number is <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
+    <!--<p class="govuk-body">You may want to send a text message to {{ case.serviceUserPersonalDetails.firstName }}. {{ case.serviceUserPersonalDetails.firstName }}'s phone number is <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
     <!--<p class="govuk-body">The session will be added to your Outlook calendar.</p>
-          <p class="govuk-body">A text message will be sent to Dylan on <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
-    <p class="govuk-body"><a href="../progress">Back to Dylan's progress</a></p>
+          <p class="govuk-body">A text message will be sent to {{ case.serviceUserPersonalDetails.firstName }} on <strong>07700 900 796</strong>. <a href="#">Update phone number</a>.</p>-->
+    <p class="govuk-body"><a href="../progress">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a></p>
 
 
 

--- a/app/views/prototype/confirm-attendance/attendance-add-1.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-1.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-1.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-1.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to Dylan's previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-1b.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-1b.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-1b.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-1b.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to Dylan's previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-2.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-2.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-2.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-2.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to Dylan's previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-2b-remove-RAR.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-2b-remove-RAR.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-2b-remove-RAR.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-2b-remove-RAR.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to Dylan's previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-3.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-3.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-3.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-3.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to Dylan's previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
 {% endblock %}
 
 {% block content %}
@@ -26,7 +26,7 @@ Case summary
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h2 class="govuk-fieldset__heading">
-              Did Dylan comply?
+              Did {{ case.serviceUserPersonalDetails.firstName }} comply?
             </h2>
           </legend>
           <div class="govuk-radios govuk-radios">
@@ -45,7 +45,7 @@ Case summary
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="over18-absent" name="comply" type="radio">
               <label class="govuk-label govuk-radios__label" for="comply-absent">
-                Dylan was absent
+                {{ case.serviceUserPersonalDetails.firstName }} was absent
               </label>
             </div>
           </div>

--- a/app/views/prototype/confirm-attendance/attendance-add-3b.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-3b.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-3b.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-3b.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to Dylan's previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
 {% endblock %}
 
 {% block content %}
@@ -26,7 +26,7 @@ Case summary
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h2 class="govuk-fieldset__heading">
-              Did Dylan comply?
+              Did {{ case.serviceUserPersonalDetails.firstName }} comply?
             </h2>
           </legend>
           <div class="govuk-radios govuk-radios">
@@ -45,7 +45,7 @@ Case summary
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="over18-absent" name="comply" type="radio">
               <label class="govuk-label govuk-radios__label" for="comply-absent">
-                Dylan was absent
+                {{ case.serviceUserPersonalDetails.firstName }} was absent
               </label>
             </div>
           </div>

--- a/app/views/prototype/confirm-attendance/attendance-add-4.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-4.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-4.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-4.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to Dylan's previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
 {% endblock %}
 
 {% block content %}
@@ -27,7 +27,7 @@ Case summary
         <fieldset class="govuk-fieldset" aria-describedby="contact-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
-              How did Dylan not comply?
+              How did {{ case.serviceUserPersonalDetails.firstName }} not comply?
             </h1>
           </legend>
           <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">

--- a/app/views/prototype/confirm-attendance/attendance-add-4b.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-4b.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-4b.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-4b.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to Dylan's previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
 {% endblock %}
 
 {% block content %}
@@ -27,7 +27,7 @@ Case summary
         <fieldset class="govuk-fieldset" aria-describedby="contact-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
-              How did Dylan not comply?
+              How did {{ case.serviceUserPersonalDetails.firstName }} not comply?
             </h1>
           </legend>
           <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">

--- a/app/views/prototype/confirm-attendance/attendance-add-5.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-5.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to Dylan's previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
 {% endblock %}
 
 {% block content %}
@@ -27,7 +27,7 @@ Case summary
         <fieldset class="govuk-fieldset" aria-describedby="contact-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
-              Was Dylan's absence acceptable?
+              Was {{ case.serviceUserPersonalDetails.firstName }}'s absence acceptable?
             </h1>
           </legend>
           <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">

--- a/app/views/prototype/confirm-attendance/attendance-add-5.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-5.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</a>
 {% endblock %}
 
 {% block content %}
@@ -27,7 +27,7 @@ Case summary
         <fieldset class="govuk-fieldset" aria-describedby="contact-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
-              Was {{ case.serviceUserPersonalDetails.firstName }}'s absence acceptable?
+              Was {{ case.serviceUserPersonalDetails.firstName }}’s absence acceptable?
             </h1>
           </legend>
           <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">

--- a/app/views/prototype/confirm-attendance/attendance-add-5b.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-5b.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to Dylan's previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
 {% endblock %}
 
 {% block content %}
@@ -27,7 +27,7 @@ Case summary
         <fieldset class="govuk-fieldset" aria-describedby="contact-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
-              Was Dylan's absence acceptable?
+              Was {{ case.serviceUserPersonalDetails.firstName }}'s absence acceptable?
             </h1>
           </legend>
           <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">

--- a/app/views/prototype/confirm-attendance/attendance-add-5b.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-5b.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</a>
 {% endblock %}
 
 {% block content %}
@@ -27,7 +27,7 @@ Case summary
         <fieldset class="govuk-fieldset" aria-describedby="contact-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
-              Was {{ case.serviceUserPersonalDetails.firstName }}'s absence acceptable?
+              Was {{ case.serviceUserPersonalDetails.firstName }}’s absence acceptable?
             </h1>
           </legend>
           <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">

--- a/app/views/prototype/confirm-attendance/attendance-add-6.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-6.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-6.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-6.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to Dylan's previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-6b.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-6b.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-6b.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-6b.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to Dylan's previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-7.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-7.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-7.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-7.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to Dylan's previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-7b.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-7b.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-7b.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-7b.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to Dylan's previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-8.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-8.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to Dylan's progress</a>
+<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -41,7 +41,7 @@ Case summary
         </div>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            Dylan complied
+            {{ case.serviceUserPersonalDetails.firstName }} complied
           </dt>
           <dd class="govuk-summary-list__value">
             Yes

--- a/app/views/prototype/confirm-attendance/attendance-add-8.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-8.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-8b-remove-RAR.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-8b-remove-RAR.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to Dylan's progress</a>
+<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
 {% endblock %}
 
 {% block content %}
@@ -41,7 +41,7 @@ Case summary
         </div>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            Dylan complied
+            {{ case.serviceUserPersonalDetails.firstName }} complied
           </dt>
           <dd class="govuk-summary-list__value">
             Yes

--- a/app/views/prototype/confirm-attendance/attendance-add-8b-remove-RAR.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-8b-remove-RAR.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s progress</a>
+<a href="progress" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s progress</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/confirm-attendance/attendance-add-9.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-9.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../timeline" class="govuk-back-link">Back to Dylan's previous sessions</a>
+<a href="../timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
 {% endblock %}
 
 {% block content %}
@@ -40,7 +40,7 @@ Case summary
     </a>
 
     <div style="margin-top: 20px;">
-      <a class="govuk-body" href="../timeline">Back to Dylan's previous sessions</a>
+      <a class="govuk-body" href="../timeline">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
     </div>
 
   </div>

--- a/app/views/prototype/confirm-attendance/attendance-add-9.html
+++ b/app/views/prototype/confirm-attendance/attendance-add-9.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="../timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
+<a href="../timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</a>
 {% endblock %}
 
 {% block content %}
@@ -40,7 +40,7 @@ Case summary
     </a>
 
     <div style="margin-top: 20px;">
-      <a class="govuk-body" href="../timeline">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
+      <a class="govuk-body" href="../timeline">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</a>
     </div>
 
   </div>

--- a/app/views/prototype/details.html
+++ b/app/views/prototype/details.html
@@ -23,7 +23,7 @@ Case summary
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">Dylan's details</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}'s details</h1>
   </div>
 </div>
 
@@ -82,7 +82,7 @@ Case summary
             Name
           </dt>
           <dd class="govuk-summary-list__value">
-            Dylan Adam Armstrong
+            {{ case.serviceUserPersonalDetails.name }}
           </dd>
           <dd class="govuk-summary-list__actions">
           </dd>

--- a/app/views/prototype/details.html
+++ b/app/views/prototype/details.html
@@ -123,60 +123,6 @@ Case summary
       View more personal details
     </a>
 
-    <!--<div class="govuk-!-margin-bottom-7">
-    <details class="govuk-details" data-module="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          View more personal details
-        </span>
-      </summary>
-      <div class="govuk-details__text">
-          <dl class="govuk-summary-list govuk-summary-list--no-border">
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Nationality
-              </dt>
-              <dd class="govuk-summary-list__value">
-                British
-              </dd>
-            </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Ethnicity
-              </dt>
-              <dd class="govuk-summary-list__value">
-                White: British
-              </dd>
-            </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Religion or belief
-              </dt>
-              <dd class="govuk-summary-list__value">
-                None
-              </dd>
-            </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Gender
-              </dt>
-              <dd class="govuk-summary-list__value">
-                Male
-              </dd>
-            </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Sexual orientation
-              </dt>
-              <dd class="govuk-summary-list__value">
-                Heterosexual
-              </dd>
-            </div>
-          </dl>
-        </div>
-    </details>
-    </div>-->
-
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
     <div class="govuk-!-margin-bottom-7">

--- a/app/views/prototype/details.html
+++ b/app/views/prototype/details.html
@@ -41,10 +41,7 @@ Case summary
             Address
           </dt>
           <dd class="govuk-summary-list__value">
-            1 Grey Lane<br>
-            Sheffield<br>
-            South Yorkshire<br>
-            S10 1AG
+            {{ case.serviceUserPersonalDetails.address.join('<br>') | safe }}
           </dd>
         </div>
         <div class="govuk-summary-list__row">

--- a/app/views/prototype/details.html
+++ b/app/views/prototype/details.html
@@ -49,7 +49,7 @@ Case summary
             Phone number
           </dt>
           <dd class="govuk-summary-list__value">
-            07700 900 077
+            {{ case.serviceUserPersonalDetails.phone }}
           </dd>
         </div>
         <div class="govuk-summary-list__row">
@@ -57,7 +57,7 @@ Case summary
             Email
           </dt>
           <dd class="govuk-summary-list__value">
-            example@example.com
+            {{ case.serviceUserPersonalDetails.email }}
           </dd>
         </div>
       </dl>
@@ -89,7 +89,7 @@ Case summary
             Aliases
           </dt>
           <dd class="govuk-summary-list__value">
-            Dee
+            {{ case.serviceUserPersonalDetails.aliases.join(', ') }}
           </dd>
         </div>
         <div class="govuk-summary-list__row">
@@ -97,7 +97,7 @@ Case summary
             Date of birth
           </dt>
           <dd class="govuk-summary-list__value">
-            27 September 1984 (35 years old)
+            {{ case.serviceUserPersonalDetails.dateOfBirth | dateWithYear }} ({{ case.serviceUserPersonalDetails.age }} years old)
           </dd>
         </div>
         <div class="govuk-summary-list__row">
@@ -105,7 +105,7 @@ Case summary
             Preferred language
           </dt>
           <dd class="govuk-summary-list__value">
-            English
+            {{ case.serviceUserPersonalDetails.preferredLanguage }}
           </dd>
         </div>
         <div class="govuk-summary-list__row">
@@ -113,7 +113,7 @@ Case summary
             Disabilities and adjustments
           </dt>
           <dd class="govuk-summary-list__value">
-            Autism spectrum condition
+            {{ case.serviceUserPersonalDetails.disabilitiesAndAdjustments.join(', ') }}
           </dd>
         </div>
       </dl>
@@ -189,7 +189,7 @@ Case summary
             Employment status
           </dt>
           <dd class="govuk-summary-list__value">
-            Full-time employed
+            {{ case.serviceUserPersonalDetails.circumstances.employment }}
           </dd>
         </div>
         <div class="govuk-summary-list__row">
@@ -197,7 +197,7 @@ Case summary
             Housing status
           </dt>
           <dd class="govuk-summary-list__value">
-            Living alone
+            {{ case.serviceUserPersonalDetails.circumstances.housingStatus }}
           </dd>
         </div>
         <div class="govuk-summary-list__row">
@@ -205,7 +205,7 @@ Case summary
             Safeguarding issues
           </dt>
           <dd class="govuk-summary-list__value">
-            None
+            {{ case.serviceUserPersonalDetails.circumstances.safeguardingIssues.join(', ') or 'None' }}
           </dd>
         </div>
       </dl>

--- a/app/views/prototype/details.html
+++ b/app/views/prototype/details.html
@@ -35,32 +35,24 @@ Case summary
       <h2 class="govuk-heading-m">
         Contact details
       </h2>
-      <dl class="govuk-summary-list govuk-summary-list--no-border">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Address
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ case.serviceUserPersonalDetails.address.join('<br>') | safe }}
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Phone number
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ case.serviceUserPersonalDetails.phone }}
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Email
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ case.serviceUserPersonalDetails.email }}
-          </dd>
-        </div>
-      </dl>
+
+      {{ govukSummaryList({
+        classes: 'govuk-summary-list--no-border',
+        rows: [
+          {
+            key: { text: "Address" },
+            value: { html: case.serviceUserPersonalDetails.address.join('<br>') }
+          },
+          {
+            key: { text: "Phone number" },
+            value: { text: case.serviceUserPersonalDetails.phone }
+          },
+          {
+            key: { text: "Email" },
+            value: { text: case.serviceUserPersonalDetails.email }
+          }
+        ]
+      }) }}
     </div>
 
     <a class="govuk-body" href="address-book-personal">
@@ -73,50 +65,36 @@ Case summary
       <h2 class="govuk-heading-m">
         Personal details
       </h2>
-      <dl class="govuk-summary-list govuk-summary-list--no-border">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Name
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ case.serviceUserPersonalDetails.name }}
-          </dd>
-          <dd class="govuk-summary-list__actions">
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Aliases
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ case.serviceUserPersonalDetails.aliases.join(', ') }}
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Date of birth
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ case.serviceUserPersonalDetails.dateOfBirth | dateWithYear }} ({{ case.serviceUserPersonalDetails.age }} years old)
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Preferred language
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ case.serviceUserPersonalDetails.preferredLanguage }}
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Disabilities and adjustments
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ case.serviceUserPersonalDetails.disabilitiesAndAdjustments.join(', ') }}
-          </dd>
-        </div>
-      </dl>
+
+      {% set dateOfBirthAndAge %}
+        {{ case.serviceUserPersonalDetails.dateOfBirth | dateWithYear }} ({{ case.serviceUserPersonalDetails.age }} years old)
+      {% endset %}
+
+      {{ govukSummaryList({
+        classes: 'govuk-summary-list--no-border',
+        rows: [
+          {
+            key: { text: "Name" },
+            value: { text: case.serviceUserPersonalDetails.name }
+          },
+          {
+            key: { text: "Aliases" },
+            value: { text: case.serviceUserPersonalDetails.aliases.join(', ') }
+          },
+          {
+            key: { text: "Date of birth" },
+            value: { text: dateOfBirthAndAge }
+          },
+          {
+            key: { text: "Preferred language" },
+            value: { text: case.serviceUserPersonalDetails.preferredLanguage }
+          },
+          {
+            key: { text: "Disabilities and adjustments" },
+            value: { text: case.serviceUserPersonalDetails.disabilitiesAndAdjustments.join(', ') }
+          }
+        ]
+      }) }}
     </div>
 
     <a class="govuk-body" href="personal-details">
@@ -129,32 +107,24 @@ Case summary
       <h2 class="govuk-heading-m">
         Circumstances
       </h2>
-      <dl class="govuk-summary-list govuk-summary-list--no-border">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Employment status
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ case.serviceUserPersonalDetails.circumstances.employment }}
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Housing status
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ case.serviceUserPersonalDetails.circumstances.housingStatus }}
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Safeguarding issues
-          </dt>
-          <dd class="govuk-summary-list__value">
-            {{ case.serviceUserPersonalDetails.circumstances.safeguardingIssues.join(', ') or 'None' }}
-          </dd>
-        </div>
-      </dl>
+
+      {{ govukSummaryList({
+        classes: 'govuk-summary-list--no-border',
+        rows: [
+          {
+            key: { text: "Employment status" },
+            value: { text: case.serviceUserPersonalDetails.circumstances.employment }
+          },
+          {
+            key: { text: "Housing status" },
+            value: { text: case.serviceUserPersonalDetails.circumstances.housingStatus }
+          },
+          {
+            key: { text: "Safeguarding issues" },
+            value: { text: case.serviceUserPersonalDetails.circumstances.safeguardingIssues.join(', ') or 'None' }
+          }
+        ]
+      }) }}
     </div>
 
     <a class="govuk-body" href="#">
@@ -179,8 +149,6 @@ Case summary
         </ul>
       </div>
     </div>
-
-
 
   </div>
 

--- a/app/views/prototype/details.html
+++ b/app/views/prototype/details.html
@@ -23,7 +23,7 @@ Case summary
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}'s details</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}’s details</h1>
   </div>
 </div>
 

--- a/app/views/prototype/notes-add.html
+++ b/app/views/prototype/notes-add.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/notes-add.html
+++ b/app/views/prototype/notes-add.html
@@ -13,7 +13,7 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="timeline" class="govuk-back-link">Back to Dylan's previous sessions</a>
+<a href="timeline" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/prototype/personal-details.html
+++ b/app/views/prototype/personal-details.html
@@ -13,14 +13,14 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="details" class="govuk-back-link">Back to Dylan's details</a>
+<a href="details" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s details</a>
 {% endblock %}
 
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">Dylan's personal details</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}'s personal details</h1>
   </div>
 </div>
 
@@ -31,7 +31,7 @@ Case summary
         Name
       </dt>
       <dd class="govuk-summary-list__value">
-        Dylan Adam Armstrong
+        {{ case.serviceUserPersonalDetails.name }}
       </dd>
       <dd class="govuk-summary-list__actions">
       </dd>

--- a/app/views/prototype/personal-details.html
+++ b/app/views/prototype/personal-details.html
@@ -13,14 +13,14 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="details" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s details</a>
+<a href="details" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s details</a>
 {% endblock %}
 
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}'s personal details</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}’s personal details</h1>
   </div>
 </div>
 

--- a/app/views/prototype/personal-details.html
+++ b/app/views/prototype/personal-details.html
@@ -25,90 +25,55 @@ Case summary
 </div>
 
 <div class="govuk-!-margin-bottom-7">
-  <dl class="govuk-summary-list govuk-summary-list--no-border">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Name
-      </dt>
-      <dd class="govuk-summary-list__value">
-        {{ case.serviceUserPersonalDetails.name }}
-      </dd>
-      <dd class="govuk-summary-list__actions">
-      </dd>
-    </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Aliases
-      </dt>
-      <dd class="govuk-summary-list__value">
-        {{ case.serviceUserPersonalDetails.aliases.join(', ') }}
-      </dd>
-    </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Date of birth
-      </dt>
-      <dd class="govuk-summary-list__value">
-        {{ case.serviceUserPersonalDetails.dateOfBirth | dateWithYear }} ({{ case.serviceUserPersonalDetails.age }} years old)
-      </dd>
-    </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Preferred language
-      </dt>
-      <dd class="govuk-summary-list__value">
-        {{ case.serviceUserPersonalDetails.preferredLanguage }}
-      </dd>
-    </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Disabilities and adjustments
-      </dt>
-      <dd class="govuk-summary-list__value">
-        {{ case.serviceUserPersonalDetails.disabilitiesAndAdjustments.join(', ') }}
-      </dd>
-    </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Nationality
-      </dt>
-      <dd class="govuk-summary-list__value">
-        {{ case.serviceUserPersonalDetails.nationality }}
-      </dd>
-    </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Ethnicity
-      </dt>
-      <dd class="govuk-summary-list__value">
-        {{ case.serviceUserPersonalDetails.ethnicity }}
-      </dd>
-    </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Religion or belief
-      </dt>
-      <dd class="govuk-summary-list__value">
-        {{ case.serviceUserPersonalDetails.religion }}
-      </dd>
-    </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Gender
-      </dt>
-      <dd class="govuk-summary-list__value">
-        {{ case.serviceUserPersonalDetails.gender }}
-      </dd>
-    </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        Sexual orientation
-      </dt>
-      <dd class="govuk-summary-list__value">
-        {{ case.serviceUserPersonalDetails.sexualOrientation }}
-      </dd>
-    </div>
-  </dl>
+  {% set dateOfBirthAndAge %}
+    {{ case.serviceUserPersonalDetails.dateOfBirth | dateWithYear }} ({{ case.serviceUserPersonalDetails.age }} years old)
+  {% endset %}
+
+  {{ govukSummaryList({
+    classes: 'govuk-summary-list--no-border',
+    rows: [
+      {
+        key: { text: "Name" },
+        value: { text: case.serviceUserPersonalDetails.name }
+      },
+      {
+        key: { text: "Aliases" },
+        value: { text: case.serviceUserPersonalDetails.aliases.join(', ') }
+      },
+      {
+        key: { text: "Date of birth" },
+        value: { text: dateOfBirthAndAge }
+      },
+      {
+        key: { text: "Preferred language" },
+        value: { text: case.serviceUserPersonalDetails.preferredLanguage }
+      },
+      {
+        key: { text: "Disabilities and adjustments" },
+        value: { text: case.serviceUserPersonalDetails.disabilitiesAndAdjustments.join(', ') }
+      },
+      {
+        key: { text: "Nationality" },
+        value: { text: case.serviceUserPersonalDetails.nationality }
+      },
+      {
+        key: { text: "Ethnicity" },
+        value: { text: case.serviceUserPersonalDetails.ethnicity }
+      },
+      {
+        key: { text: "Religion or belief" },
+        value: { text: case.serviceUserPersonalDetails.religion }
+      },
+      {
+        key: { text: "Gender" },
+        value: { text: case.serviceUserPersonalDetails.gender }
+      },
+      {
+        key: { text: "Sexual orientation" },
+        value: { text: case.serviceUserPersonalDetails.sexualOrientation }
+      }
+    ]
+  }) }}
 </div>
 
 {% endblock %}

--- a/app/views/prototype/personal-details.html
+++ b/app/views/prototype/personal-details.html
@@ -41,7 +41,7 @@ Case summary
         Aliases
       </dt>
       <dd class="govuk-summary-list__value">
-        Dee
+        {{ case.serviceUserPersonalDetails.aliases.join(', ') }}
       </dd>
     </div>
     <div class="govuk-summary-list__row">
@@ -49,7 +49,7 @@ Case summary
         Date of birth
       </dt>
       <dd class="govuk-summary-list__value">
-        27 September 1984 (35 years old)
+        {{ case.serviceUserPersonalDetails.dateOfBirth | dateWithYear }} ({{ case.serviceUserPersonalDetails.age }} years old)
       </dd>
     </div>
     <div class="govuk-summary-list__row">
@@ -57,7 +57,7 @@ Case summary
         Preferred language
       </dt>
       <dd class="govuk-summary-list__value">
-        English
+        {{ case.serviceUserPersonalDetails.preferredLanguage }}
       </dd>
     </div>
     <div class="govuk-summary-list__row">
@@ -65,7 +65,7 @@ Case summary
         Disabilities and adjustments
       </dt>
       <dd class="govuk-summary-list__value">
-        Autism spectrum condition
+        {{ case.serviceUserPersonalDetails.disabilitiesAndAdjustments.join(', ') }}
       </dd>
     </div>
     <div class="govuk-summary-list__row">
@@ -73,7 +73,7 @@ Case summary
         Nationality
       </dt>
       <dd class="govuk-summary-list__value">
-        British
+        {{ case.serviceUserPersonalDetails.nationality }}
       </dd>
     </div>
     <div class="govuk-summary-list__row">
@@ -81,7 +81,7 @@ Case summary
         Ethnicity
       </dt>
       <dd class="govuk-summary-list__value">
-        White: British
+        {{ case.serviceUserPersonalDetails.ethnicity }}
       </dd>
     </div>
     <div class="govuk-summary-list__row">
@@ -89,7 +89,7 @@ Case summary
         Religion or belief
       </dt>
       <dd class="govuk-summary-list__value">
-        None
+        {{ case.serviceUserPersonalDetails.religion }}
       </dd>
     </div>
     <div class="govuk-summary-list__row">
@@ -97,7 +97,7 @@ Case summary
         Gender
       </dt>
       <dd class="govuk-summary-list__value">
-        Male
+        {{ case.serviceUserPersonalDetails.gender }}
       </dd>
     </div>
     <div class="govuk-summary-list__row">
@@ -105,14 +105,10 @@ Case summary
         Sexual orientation
       </dt>
       <dd class="govuk-summary-list__value">
-        Heterosexual
+        {{ case.serviceUserPersonalDetails.sexualOrientation }}
       </dd>
     </div>
   </dl>
-</div>
-
-</div>
-
 </div>
 
 {% endblock %}

--- a/app/views/prototype/plan.html
+++ b/app/views/prototype/plan.html
@@ -23,7 +23,7 @@ Case summary
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}'s plan</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}’s plan</h1>
   </div>
 </div>
 

--- a/app/views/prototype/plan.html
+++ b/app/views/prototype/plan.html
@@ -23,7 +23,7 @@ Case summary
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">Dylan's plan</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}'s plan</h1>
   </div>
 </div>
 

--- a/app/views/prototype/previous-orders.html
+++ b/app/views/prototype/previous-orders.html
@@ -13,14 +13,14 @@ Case summary
 {% endblock %}
 
 {% block beforeContent %}
-<a href="sentence" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}'s sentence</a>
+<a href="sentence" class="govuk-back-link">Back to {{ case.serviceUserPersonalDetails.firstName }}’s sentence</a>
 {% endblock %}
 
 {% block content %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}'s previous orders</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}’s previous orders</h1>
   </div>
 </div>
 

--- a/app/views/prototype/progress.html
+++ b/app/views/prototype/progress.html
@@ -23,7 +23,7 @@ Case summary
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}'s progress</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}’s progress</h1>
   </div>
 </div>
 

--- a/app/views/prototype/sentence.html
+++ b/app/views/prototype/sentence.html
@@ -23,7 +23,7 @@ Case summary
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}'s sentence</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}’s sentence</h1>
   </div>
 </div>
 
@@ -148,7 +148,7 @@ Case summary
       </div>
 
    </div>
-    <h2 class="govuk-heading-m">{{ case.serviceUserPersonalDetails.firstName }}'s history</h2>
+    <h2 class="govuk-heading-m">{{ case.serviceUserPersonalDetails.firstName }}’s history</h2>
 
     <!--TIME ARRANGED-->
 <div class="govuk-panel govuk-panel--appointment-timeline">

--- a/app/views/prototype/timeline-b.html
+++ b/app/views/prototype/timeline-b.html
@@ -22,7 +22,7 @@ Case summary
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</h1>
   </div>
 </div>
 
@@ -95,7 +95,7 @@ Case summary
         </p>
       </div>-->
 
-      <h2 class="govuk-heading-m">{{ case.serviceUserPersonalDetails.firstName }}'s session summary</h2>
+      <h2 class="govuk-heading-m">{{ case.serviceUserPersonalDetails.firstName }}’s session summary</h2>
       <p class="govuk-body">Summary up to and including 22 April 2021</p>
 
       <div class="govuk-!-margin-bottom-7">

--- a/app/views/prototype/timeline-b.html
+++ b/app/views/prototype/timeline-b.html
@@ -95,7 +95,7 @@ Case summary
         </p>
       </div>-->
 
-      <h2 class="govuk-heading-m">Dylan's session summary</h2>
+      <h2 class="govuk-heading-m">{{ case.serviceUserPersonalDetails.firstName }}'s session summary</h2>
       <p class="govuk-body">Summary up to and including 22 April 2021</p>
 
       <div class="govuk-!-margin-bottom-7">

--- a/app/views/prototype/timeline.html
+++ b/app/views/prototype/timeline.html
@@ -22,7 +22,7 @@ Case summary
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}'s previous sessions</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-7">{{ case.serviceUserPersonalDetails.firstName }}’s previous sessions</h1>
   </div>
 </div>
 
@@ -95,7 +95,7 @@ Case summary
         </p>
       </div>-->
 
-      <h2 class="govuk-heading-m">{{ case.serviceUserPersonalDetails.firstName }}'s session summary</h2>
+      <h2 class="govuk-heading-m">{{ case.serviceUserPersonalDetails.firstName }}’s session summary</h2>
       <p class="govuk-body">Summary up to and including 22 April 2021</p>
 
       <div class="govuk-!-margin-bottom-7">

--- a/app/views/prototype/timeline.html
+++ b/app/views/prototype/timeline.html
@@ -95,7 +95,7 @@ Case summary
         </p>
       </div>-->
 
-      <h2 class="govuk-heading-m">Dylan's session summary</h2>
+      <h2 class="govuk-heading-m">{{ case.serviceUserPersonalDetails.firstName }}'s session summary</h2>
       <p class="govuk-body">Summary up to and including 22 April 2021</p>
 
       <div class="govuk-!-margin-bottom-7">


### PR DESCRIPTION
## Main changes

- Remove all hard-coded references to Dylan
- Remove all hard-coded personal details and contact details

This should account for the majority of the remaining hard-coded data in the pages.

## Minor changes

- Fix the 'My cases' link on all pages
- Use typographical quotes instead of straight quotes
- Fix back-links in the update/cancel session flow
- Use the `govukSummaryList` macro on a few summary lists, to make them easier to parse